### PR TITLE
New maintainer + dependency fix

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,5 @@ drat.sh
 knitreadme.sh
 CONTRIBUTING.md
 ^\.github.?
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: aws.sns
 Type: Package
 Title: AWS SNS Client Package
-Version: 0.1.7
+Version: 0.1.7.9000
 Date: 2017-07-02
 Authors@R: c(person("Thomas J.", "Leeper", role = c("aut"),
                     email = "thosjleeper@gmail.com",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,6 @@ Authors@R: c(person("Thomas J.", "Leeper", role = c("aut"),
                     comment = c(ORCID = "0000-0003-4097-6326")),
              person("Antoine", "Sachet", role = c("cre"),
                     email = "antoine.sac@gmail.com"))
-Maintainer: ORPHANED
 Description: A simple client package for the Amazon Web Services ('AWS') Simple
     Notification Service ('SNS') 'API' <https://aws.amazon.com/sns/>.
 License: GPL (>= 2)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: aws.sns
 Type: Package
 Title: AWS SNS Client Package
-Version: 0.1.7.9000
+Version: 0.1.8
 Date: 2017-07-02
 Authors@R: c(person("Thomas J.", "Leeper", role = c("aut"),
                     email = "thosjleeper@gmail.com",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,9 @@ Version: 0.1.7.9000
 Date: 2017-07-02
 Authors@R: c(person("Thomas J.", "Leeper", role = c("aut"),
                     email = "thosjleeper@gmail.com",
-                    comment = c(ORCID = "0000-0003-4097-6326")))
+                    comment = c(ORCID = "0000-0003-4097-6326")),
+             person("Antoine", "Sachet", role = c("cre"),
+                    email = "antoine.sac@gmail.com"))
 Maintainer: ORPHANED
 Description: A simple client package for the Amazon Web Services ('AWS') Simple
     Notification Service ('SNS') 'API' <https://aws.amazon.com/sns/>.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # aws.sns devel
 
-* New maintainer: antoine-sachet
+* New maintainer: antoine-sachet (#6)
+
+* Fix dependency issue with `locate_credentials()` (#5).
 
 # aws.sns 0.1.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# aws.sns devel
+# aws.sns 0.1.8
 
 * New maintainer: antoine-sachet (#6)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,15 +1,19 @@
-# CHANGES TO aws.sns 0.1.7
+# aws.sns devel
+
+* New maintainer: antoine-sachet
+
+# aws.sns 0.1.7
 
 * Changed `add_permission()` to `add_topic_permission()` and `remove_permission()` to `remove_topic_permission()` to avoid namespace conflict with **aws.sqs**.
 
-# CHANGES TO aws.sns 0.1.6
+# aws.sns 0.1.6
 
 * Bump **aws.signature** dependency to 0.3.4.
 
-# CHANGES TO aws.sns 0.1.5
+# aws.sns 0.1.5
 
 * Add examples and cleanup documentation.
 
-# CHANGES TO aws.sns 0.1.1
+# aws.sns 0.1.1
 
 * Initial release.

--- a/R/http.r
+++ b/R/http.r
@@ -28,7 +28,7 @@ function(
   ...
 ) {
     # locate and validate credentials
-    credentials <- locate_credentials(key = key, secret = secret, session_token = session_token, region = region, verbose = verbose)
+    credentials <- aws.signature::locate_credentials(key = key, secret = secret, session_token = session_token, region = region, verbose = verbose)
     key <- credentials[["key"]]
     secret <- credentials[["secret"]]
     session_token <- credentials[["session_token"]]


### PR DESCRIPTION
This PR would make me the maintainer (which would allow the package to be installed directly from github) and contains a bug fix. As I mentioned in issue #6, I already maintain a few of cloudyr's aws packages (aws.polly, aws.transcribe, aws.comprehend, aws.translate) and I am willing to maintain this one too since I actively use it.

The NEWS file has been updated and I've incremented the version number. R CMD check runs without errors, warnings or notes.

From the NEWS file:

```
# aws.sns 0.1.8

* New maintainer: antoine-sachet (#6)

* Fix dependency issue with `locate_credentials()` (#5).
```